### PR TITLE
Fix tab (\t) conversion

### DIFF
--- a/src/cp437.rs
+++ b/src/cp437.rs
@@ -4,9 +4,9 @@ pub fn convert_byte(b : &u8) -> &'static str {
 		0x06 => " ", // 	0x0006	//ACKNOWLEDGE
 		0x07 => " ", // 	0x0007	//BELL
 		0x08 => " ", // 	0x0008	//BACKSPACE
-		0x09 => " ", // 	0x0009	//HORIZONTAL TABULATION
+		0x09 => "\t", // 	0x0009	//HORIZONTAL TABULATION
 		0x0a => "\n", // 	0x000a	//LINE FEED
-		0x0b => "\t", // 	0x000b	//VERTICAL TABULATION
+		0x0b => " ", // 	0x000b	//VERTICAL TABULATION
 		0x0c => " ", // 	0x000c	//FORM FEED
 		0x0d => " ", // 	0x000d	//CARRIAGE RETURN
 		0x0e => " ", // 	0x000e	//SHIFT OUT


### PR DESCRIPTION
Hi, cool crate! I've added CP437 support to my Gopher client [phetch](https://github.com/xvxx/phetch) using it.

The Gopher protocol uses a lot of `TAB` characters, and I noticed they were getting converted into spaces. Checking the code, it looks like `\t` and `\v` got swapped. This PR should fix it.

You can verify that `\t` is `0x09` in Rust with `println!("HT: {}", '\t' as u8);` [(playground link)](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=29e4a7d4efd4b7d95dc2b40ded6b17c2).

Thanks!